### PR TITLE
bugfix: quell crash while checking a non-existent directory

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -74,9 +74,9 @@ extern QString vymName;
 bool reallyWriteDirectory(const QString &dir)
 {
     QStringList eList = QDir(dir).entryList();
-    if (eList.first() == ".")
+    if (!eList.isEmpty() && (eList.first() == "."))
         eList.pop_front(); // remove "."
-    if (eList.first() == "..")
+    if (!eList.isEmpty() && (eList.first() == ".."))
         eList.pop_front(); // remove "."
     if (!eList.isEmpty()) {
         QMessageBox mb(vymName,


### PR DESCRIPTION
Observed on Windows with MSVS 2019 and Qt 5.15.1:
When exporting to XML and the given target doesn't yet exist, the entry
list of it is empty. Then, accessing the first element of the empty list
lets the program crash.

Surprising that this seems to be not an issue for other systems.