### PR TITLE
bugfix: quell crash while checking an empty directory

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -79,7 +79,7 @@ bool confirmDirectoryOverwrite(const QDir &dir)
     }
 
     QStringList eList = dir.entryList();
-    while (eList.first() == "." || eList.first() == "..")
+    while (!eList.isEmpty() && (eList.first() == "." || eList.first() == ".."))
         eList.pop_front(); // remove "." and ".."
 
     if (!eList.isEmpty()) {


### PR DESCRIPTION
Observed on Windows with MSVS 2019 and Qt 5.15.1:
When exporting to XML and the given target directory exists but is
empty, the entry list of it is empty. Then, accessing the first element
of the empty list lets the program crash.