### PR TITLE
new feature: context menu for TreeEditor

### DIFF
--- a/src/treeeditor.cpp
+++ b/src/treeeditor.cpp
@@ -1,6 +1,7 @@
 #include "treeeditor.h"
 
 #include <QAction>
+#include <QMenu>
 #include <QRegExp>
 
 #include "mainwindow.h"
@@ -8,6 +9,10 @@
 
 extern Main *mainWindow;
 extern QString editorFocusStyle;
+
+extern QMenu *branchContextMenu;
+extern QMenu *canvasContextMenu;
+extern QMenu *floatimageContextMenu;
 
 ///////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////
@@ -80,6 +85,19 @@ QModelIndex TreeEditor::getSelectedIndex()
         return QModelIndex();
     else
         return list.first();
+}
+
+void TreeEditor::contextMenuEvent(QContextMenuEvent *e) {
+    if (model->getSelectedBranch())
+        branchContextMenu->popup(e->globalPos());
+    else if (model->getSelectedImage())
+        floatimageContextMenu->popup(e->globalPos());
+    else if (model->getSelectedXLink())
+        model->editXLink();
+    else
+        canvasContextMenu->exec(e->globalPos());
+
+    e->accept();
 }
 
 void TreeEditor::cursorUp()

--- a/src/treeeditor.h
+++ b/src/treeeditor.h
@@ -16,6 +16,10 @@ class TreeEditor : public QTreeView {
     ~TreeEditor();
     void init();
     QModelIndex getSelectedIndex();
+
+  protected:
+    virtual void contextMenuEvent(QContextMenuEvent *e);
+
   private slots:
     void cursorUp();
     void cursorDown();


### PR DESCRIPTION
a right mouse click opens the context menu for the selected entry;
the selection follows the standard QTreeView behavior:
- if an entry is below the mouse pointer, it will be selected and its
context menu shown
- if the mouse points to void space, the behaviour may differ (depending on Qt version and/or OS?):
    - some leave the selection as it is, then the context menu of this entry will be shown (seen with Debian buster and Qt 5.11.3)
    - some deselect the entry, then the context menu of the canvas will be shown (seen with Windows and Qt 5.15.1)
    - if no entry is selected, the context menu of the canvas will be shown