### PR TITLE
bugfix: set CMAKE_INSTALL_DATAROOTDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(ViewYourMind)
 
+include(GNUInstallDirs)
+
 set(QtComponents
     LinguistTools
     Network


### PR DESCRIPTION
via the GNUInstallDirs package