### PR TITLE
Setting Windows data-root directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.12)
 
 project(ViewYourMind)
 
-include(GNUInstallDirs)
-
 set(QtComponents
     LinguistTools
     Network
@@ -50,7 +48,11 @@ if(WIN32)
 
     #target_link_libraries(${YOUR_TARGET_HERE} ${OPENSSL_LIBRARIES})
     #target_link_libraries(project_name /path/of/libssl.so /path/of/libcrypto.so)
+
+    set(CMAKE_INSTALL_DATAROOTDIR ".")
  endif()
+
+include(GNUInstallDirs)
 
 find_package(Qt5 COMPONENTS ${QtComponents} REQUIRED)
 set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
Don't add an additional data directory (usually "share") to the Windows
installation. Instead, put the demos, doc, exports, etc. folders
immediately in the directory where the executable lies.

The GNUInstallDirs CMake module honours the value of
CMAKE_INSTALL_DATAROOTDIR - if it was set in advance. That's why its
include needs to be after the set command.