### PR TITLE
Improved user flag handling

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -136,6 +136,7 @@ extern QDir lastMapDir;
 extern QDir vymInstallDir;
 #endif
 extern QString zipToolPath;
+extern QString flagsPath;
 
 extern QColor vymBlue;
 
@@ -2720,6 +2721,19 @@ void Main::setupFlagActions()
 
     addToolBarBreak();
 
+    // Add user flags
+    QDir userFlagsDirectory(flagsPath + "user");
+    QStringList supportedImageFiles = QString("*.png *.bmp *.xbm *.jpg *.png "
+                    "*.xpm *.gif *.pnm *.svg *.svgz").split(' ');
+    QFileInfoList userFlagsList = userFlagsDirectory.entryInfoList(supportedImageFiles,
+                                    QDir::Files | QDir::NoDotAndDotDot);
+
+    for (int userFlagIndex = 0; userFlagIndex < userFlagsList.size(); ++userFlagIndex) {
+        QString userFlagPath = userFlagsList[userFlagIndex].absoluteFilePath();
+
+        setupFlag(userFlagPath, Flag::UserFlag, userFlagPath, "");
+    }
+
     // Add entry now, to avoid chicken and egg problem and position toolbar
     // after all others:
     setupFlag(":/flag-stopsign.svg", Flag::StandardFlag, "stopsign",
@@ -2912,12 +2926,34 @@ Flag *Main::setupFlag(const QString &path, Flag::FlagType type,
         flag = standardFlagsMaster->createFlag(path);
         break;
 
-    case Flag::UserFlag:
-        flag = userFlagsMaster->createFlag(path);
-
-        if (flag &&!uid.isNull())
+    case Flag::UserFlag: {
             // User flags read from file already have a Uuid - use it
-            flag->setUuid(uid);
+            // If there is no valid Uuid - generate one from image's binary representation
+            QUuid flagUuid = uid;
+
+            if (flagUuid.isNull()) {
+                QFile flagFile(path);
+
+                if (flagFile.open(QIODevice::ReadOnly)) {
+                    QByteArray flagContent = flagFile.readAll();
+                    flagUuid = QUuid::createUuidV5(QUuid(), flagContent);
+                }
+            }
+
+            if (!flagUuid.isNull()) {
+                flag = userFlagsMaster->findFlagByUid(flagUuid);
+
+                // if flag apparently exist, reuse it
+                if (flag != NULL)
+                    return flag;
+            }
+
+            flag = userFlagsMaster->createFlag(path);
+
+            if (flag &&!flagUuid.isNull())
+                // User flags read from file already have a Uuid - use it
+                flag->setUuid(flagUuid);
+        }
         break;
 
     case Flag::SystemFlag:

--- a/tex/vym.tex
+++ b/tex/vym.tex
@@ -1642,7 +1642,7 @@ directory. The exact position depends on the platform:
 The file can be edited manually, or on Mac~OS~X with Property List
 Editor (installed with xtools). On windows you can use {\tt regedit.exe}.
 
-\subsection{Path to ressources}
+\subsection{Path to ressources} \label{ressources}
 \vym will try to find its ressources (images, stylesheets, filters,
 etc.) in the following places:
 \begin{enumerate}
@@ -1652,6 +1652,15 @@ etc.) in the following places:
     \item {\tt /usr/share/vym}
     \item {\tt /usr/local/share/vym}
 \end{enumerate}
+
+\subsection{User flags}
+User, project, organization, etc.\ specific flags can be stored in the {\tt flags/user}
+subdirectory of the ressources (see \ref{ressources} above).
+This way, they will be available in the user flags toolbar at program start.
+
+The image files can be any of PNG, BMP, XBM, JPG, PNG, XPM, GIF, PNM, SVG, and SVGZ
+format.
+The file name, without the extension, will be used as the name of the flag.
 
 \subsection{Command line options} \label{options} 
 \lstinputlisting{help.tex}


### PR DESCRIPTION
- User flags get the sha1 checksum of their image bitmap as UUID (if
they don't already have one)
- This way, they will be recognized, if it isn't their first appearance,
and duplicate entries in the user flag toolbar will be avoided
- Domain-specific flags can be provided with a custom installation in
the flags/user directory