### PR TITLE
Improved renaming of lockfile to  fix #48

### DIFF
--- a/forms/branchpropeditor.ui
+++ b/forms/branchpropeditor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>325</width>
-    <height>376</height>
+    <height>378</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,7 +23,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -186,6 +186,12 @@
             </property>
             <item row="0" column="0">
              <widget class="QPushButton" name="framePenColorButton">
+              <property name="minimumSize">
+               <size>
+                <width>32</width>
+                <height>32</height>
+               </size>
+              </property>
               <property name="maximumSize">
                <size>
                 <width>20</width>
@@ -215,6 +221,12 @@
             </item>
             <item row="1" column="0">
              <widget class="QPushButton" name="frameBrushColorButton">
+              <property name="minimumSize">
+               <size>
+                <width>32</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="maximumSize">
                <size>
                 <width>20</width>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4081,7 +4081,7 @@ void Main::fileSaveAs(const SaveMode &savemode)
 
                 if (!m->renameMap(fn)) {
                     QMessageBox::critical(0, tr("Critical Error"),
-                                          tr("Couldn't rename map to %1").arg(fn));
+                                          tr("Saving the map failed:\nCouldn't rename map to %1").arg(fn));
                     return;
                 }
             }
@@ -4164,7 +4164,7 @@ void Main::fileSaveAsDefault()
 
             if (!m->renameMap(fn)) {
                 QMessageBox::critical(0, tr("Critical Error"),
-                                      tr("Couldn't save %1").arg(fn));
+                                      tr("Couldn't save as default, failed to rename to\n%1").arg(fn));
                 return;
             }
 
@@ -6341,7 +6341,7 @@ void Main::updateActions()
             standardFlagsMaster->setEnabled(false);
             userFlagsMaster->setEnabled(false);
 
-            // Disable map related actions
+            // Disable map related actions in readonly mode // FIXME-2 not all actions disabled 
             foreach (QAction *a, restrictedMapActions)
                 a->setEnabled(false);
 
@@ -6542,7 +6542,7 @@ void Main::updateActions()
                     actionMoveDown->setEnabled(false);
 
                 if ((selbi && !selbi->canMoveUp()) || selbis.count() > 1)
-                    actionMoveUpDiagonally->setEnabled(false);  // FIXME-0 add check for moveDiagonalUp
+                    actionMoveUpDiagonally->setEnabled(false);  // FIXME-2 add check for moveDiagonalUp
 
                 if ((selbi && selbi->depth() == 0) || selbis.count() > 1)
                     actionMoveDownDiagonally->setEnabled(false);

--- a/src/vymlock.cpp
+++ b/src/vymlock.cpp
@@ -6,6 +6,15 @@
 
 #include "vymlock.h"
 
+void VymLock::operator==(const VymLock &other)
+{
+    author = other.author;
+    host = other.host;
+    mapPath = other.mapPath;
+    lockPath = other.lockPath;
+    state = Undefined;  // call tryLock() to update state!
+}
+
 VymLock::VymLock() { init(); }
 
 VymLock::VymLock(const QString &fn)
@@ -16,11 +25,14 @@ VymLock::VymLock(const QString &fn)
 
 VymLock::~VymLock()
 {
-    if (state == lockedByMyself && !releaseLock())
-        qWarning() << "Destructor VymLock:  Removing LockFile failed";
+    if (state == LockedByMyself && !releaseLock())
+        qWarning() << "Destructor VymLock:  Removing LockFile failed for " << lockPath ;
 }
 
-void VymLock::init() { state = undefined; }
+void VymLock::init()
+{
+    state = Undefined;
+}
 
 bool VymLock::tryLock()
 {
@@ -45,7 +57,7 @@ bool VymLock::tryLock()
             if (match.hasMatch())
                 host = match.captured(1);
         }
-        state = lockedByOther;
+        state = LockedByOther;
         return false;
     }
 
@@ -56,7 +68,7 @@ bool VymLock::tryLock()
                        "VymLock::tryLock failed: Cannot open lockFile %1\n%2")
                        .arg(mapPath + ".lock")
                        .arg(lockFile.errorString());
-        state = notWritable;
+        state = NotWritable;
         return false;
     }
 

--- a/src/vymlock.h
+++ b/src/vymlock.h
@@ -13,21 +13,20 @@ class VymLock {
     void init();
     bool tryLock();
     LockState getState();
-    bool removeLock();
     bool releaseLock();
-    bool rename(const QString &newMapPath);
+    bool removeLockForced();
     void setAuthor(const QString &s);
     QString getAuthor();
     void setHost(const QString &s);
     QString getHost();
-    void setMapPath(const QString &s);
+    void setMapPath(const QString &path);
     QString getMapPath();
 
   private:
-    QWidget *parent;
     QString author;
     QString host;
     QString mapPath;
+    QString lockPath;
     LockState state;
 };
 

--- a/src/vymlock.h
+++ b/src/vymlock.h
@@ -5,7 +5,8 @@ extern bool debug;
 
 class VymLock {
   public:
-    enum LockState { undefined, lockedByMyself, lockedByOther, notWritable };
+    enum LockState { Undefined, LockedByMyself, LockedByOther, NotWritable };
+    void operator==(const VymLock &);
     VymLock();
     VymLock(const QString &fn);
     ~VymLock();


### PR DESCRIPTION
Now the new lockfile for new name is created, before old one is deleted.

Renaming failed on windows and caused #48