### PR TITLE
do not require explicit OpenSSL package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 if(WIN32)
     set(OPENSSL_ROOT_DIR "C:/OpenSSL-Win64")
-    find_package(OpenSSL REQUIRED)
+    find_package(OpenSSL)
 
     if( OPENSSL_FOUND )
         include_directories(${OPENSSL_INCLUDE_DIRS})


### PR DESCRIPTION
OpenSSL won't be used directly but via Qt's QSslSocket. Even on Windows, there are Qt set-ups, which include already the SSL stuff. Therefore, try the build if there is no explicit OpenSSL package too.