### PR TITLE
quell linker error

### DIFF
--- a/src/confluence-settings-dialog.cpp
+++ b/src/confluence-settings-dialog.cpp
@@ -1,9 +1,9 @@
 #include "confluence-settings-dialog.h"
 
-#include <QSettings>
+#include "settings.h"
 
 extern QString confluencePassword;
-extern QSettings settings;
+extern Settings settings;
 
 ConfluenceSettingsDialog::ConfluenceSettingsDialog(QWidget *parent) : QDialog(parent)
 {

--- a/src/default-map-settings-dialog.cpp
+++ b/src/default-map-settings-dialog.cpp
@@ -1,11 +1,10 @@
 #include "default-map-settings-dialog.h"
 
 #include <QFileDialog>
-#include <QSettings>
 
 #include "mainwindow.h"
 
-extern QSettings settings;
+extern Settings settings;
 extern Main *mainWindow;
 extern QString vymName;
 


### PR DESCRIPTION
seen with MS Visual Studio 2019