### PR TITLE
Fix: do not install manpage in doc dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ add_custom_target(make-translations-directory ALL
 add_dependencies(vym make-translations-directory)
 
 install(DIRECTORY demos DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})
-install(DIRECTORY doc DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(DIRECTORY doc DESTINATION ${CMAKE_INSTALL_DOCDIR} FILES_MATCHING PATTERN "*.pdf")
 install(FILES doc/vym.1.gz DESTINATION ${CMAKE_INSTALL_MANDIR})
 install(FILES README.md LICENSE.txt DESTINATION ${CMAKE_INSTALL_DOCDIR})
 install(DIRECTORY exports flags icons macros ${CMAKE_BINARY_DIR}/translations scripts styles DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})


### PR DESCRIPTION
This solves two issues:
a) Avoids adding the manpage also to the `${CMAKE_INSTALL_DOCDIR}`
    while it only belongs into the manpage folder.
b) Does not create a "doc" subfolder inside the `${CMAKE_INSTALL_DOCDIR}`.
    E.g. when `CMAKE_INSTALL_DOCDIR=/usr/share/doc/vym` the documentation
    pdfs end up in `/usr/share/doc/vym/doc/` which is not checked for
    by the in application Menu item to access the user guide.
    
Drawback: the file list has to be updated when new files appear in the `doc` folder in the source tree.

Alternative, if you do not consider b) or want to not do b) at all, could be:
`install(DIRECTORY doc DESTINATION ${CMAKE_INSTALL_DOCDIR} FILES_MATCHING PATTERN "*.pdf")`
which would just avoid a) from happening.