### PR TITLE
Spelling fix: remove duplicate word

### DIFF
--- a/tex/vym.tex
+++ b/tex/vym.tex
@@ -262,7 +262,7 @@ editors represent the same data and share their selection: Both show the
 {\em heading} "Get valentine surprise".
 
 More windows, each having a special purpose, can be opened and arranged
-around or even in the mainwindow. These extra windows are called
+around or even in the mainwindow. These extra windows are
 called {\em satellites}\footnote{
     The advantage of having separate window instead of integrating them
     in a combined workspace is flexibility in arranging the windows. For


### PR DESCRIPTION
That one was reported in 2013 in the Debian BTS at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=720056 because someone failed to deal with sourceforge.