### PR TITLE
Feature: link app icon as a mimetype icon for the hicolor default theme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ install(DIRECTORY exports flags icons macros ${CMAKE_BINARY_DIR}/translations sc
 
 if(UNIX)
     install(FILES icons/vym.png DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/48x48/apps)
+    file(CREATE_LINK ../apps/vym.png application-x-vym.png SYMBOLIC)
+    install(FILES ${CMAKE_BINARY_DIR}/application-x-vym.png DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/48x48/mimetypes)
     install(FILES config/vym.xml DESTINATION ${CMAKE_INSTALL_PREFIX}/share/mime/packages)
     install(FILES config/vym.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
 endif()


### PR DESCRIPTION
On Linux/Unix systems cmake already installs the vym.png application icon (what is referenced via the .desktop file) and a mime type definition for `application/x-vym`. What is missing is the icon to use on `.vym` files which are associated with this mime type. Instead of installing the icon a second time, a relativ symlink is created referencing the app icon.

I originally implemented that within the Debian package build process https://git.sven.stormbind.net/?p=sven/vym.git;a=commitdiff;h=64c3e72ec68c7c2b102f87f52b915630fe56cf3e but maybe it's helpful for others if that's implemented in the build system directly. It still only works if the "hicolor" theme is used. Drawback is that to make it really work `gtk-update-icon-cache` has to be run on the folder as well. Not sure if it's better in the end to leave all of that to the packagers to integrate.