### PR TITLE
Update Appstream Data

### DIFF
--- a/config/io.github.insilmaril.vym.appdata.xml
+++ b/config/io.github.insilmaril.vym.appdata.xml
@@ -26,7 +26,9 @@
     </categories>
     <url type="bugtracker">https://github.com/insilmaril/vym/issues</url>
     <url type="homepage">http://www.insilmaril.de/vym/</url>
-    <developer_name>vym</developer_name>
+    <developer id="io.github.insilmaril.vym">
+      <name>Uwe Drechsel</name>
+    </developer>
     <kudos>
         <kudo>HiDpiIcon</kudo>
         <kudo>HighContrast</kudo>

--- a/config/io.github.insilmaril.vym.appdata.xml
+++ b/config/io.github.insilmaril.vym.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop">
     <id>io.github.insilmaril.vym</id>
     <metadata_license>CC0-1.0</metadata_license>
-    <project_license>LGPL-2.1-or-later</project_license>
+    <project_license>GPL-2.0</project_license>
     <name>VYM</name>
     <summary>Tool for generating and manipulating mind maps</summary>
     <description>


### PR DESCRIPTION
fix: AppStream - project_license is GPL 2.0 only

chore: AppStream - replace developer_name with developer tag
`<developer_name>` is deprecated and replaced by `<developer>`

Upstream Doc:
https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer
