### PR TITLE
Support Jira Cloud

### DIFF
--- a/forms/jira-settings-dialog.ui
+++ b/forms/jira-settings-dialog.ui
@@ -79,29 +79,65 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="usePATCheckBox">
+    <widget class="QLabel" name="authMethodLabel">
      <property name="text">
-      <string>Use Personal Access Token instead of username and password for authentication</string>
+      <string>Authentication method:</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="PATLabel">
-     <property name="text">
-      <string>Personal Access Token:</string>
-     </property>
+    <widget class="QComboBox" name="authMethodComboBox">
+     <item>
+      <property name="text">
+       <string>Username/Password</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>PAT</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Cloud</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="PATLineEdit">
-     <property name="inputMethodHints">
-      <set>Qt::ImhNone</set>
-     </property>
-     <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
-     </property>
-    </widget>
-   </item>
+   <widget class="QLabel" name="PATLabel">
+    <property name="text">
+     <string>Personal Access Token:</string>
+    </property>
+   </widget>
+  </item>
+  <item>
+   <widget class="QLineEdit" name="PATLineEdit">
+    <property name="inputMethodHints">
+     <set>Qt::ImhNone</set>
+    </property>
+    <property name="echoMode">
+     <enum>QLineEdit::Password</enum>
+    </property>
+   </widget>
+  </item>
+  <item>
+   <widget class="QLabel" name="apiTokenLabel">
+    <property name="text">
+     <string>API token:</string>
+    </property>
+   </widget>
+  </item>
+  <item>
+   <widget class="QLineEdit" name="apiTokenLineEdit">
+    <property name="inputMethodHints">
+     <set>Qt::ImhNone</set>
+    </property>
+    <property name="echoMode">
+     <enum>QLineEdit::Password</enum>
+    </property>
+   </widget>
+  </item>
    <item>
     <widget class="QLabel" name="userLabel">
      <property name="text">

--- a/src/jira-agent.cpp
+++ b/src/jira-agent.cpp
@@ -60,8 +60,9 @@ void JiraAgent::init()
     QObject::connect(killTimer, SIGNAL(timeout()), this, SLOT(timeout()));
 
     // Reset credentials, these are server specific beginning in 2.9.18
-    authUsingPATInt = true;
-    personalAccessTokenInt = QString();
+    authMethodInt.clear();
+    patTokenInt = QString();
+    apiTokenInt = QString();
     userNameInt = QString();
     passwordInt = QString();
     serverNameInt = QString();
@@ -77,30 +78,31 @@ bool JiraAgent::setJiraServer(int n)
 {
     bool foundServer = false;
 
-    bool usePAT = settings.value("authUsingPAT", true).toBool();
+    QString method = settings.value("method", "userpass").toString();
     QString url = settings.value("baseUrl", "").toString();
     if (!url.isEmpty()) {
         baseUrlInt = url;
         serverNameInt = settings.value("name","-").toString();
-        QString pat = settings.value("PAT", "").toString();
-        if (!pat.isEmpty()) {
-            authUsingPATInt = true;
-            personalAccessTokenInt = pat;
-            foundServer = true;
-        }
-
-        // Looking for username and password
-        QString user = settings.value("username", "").toString();
-        if (!user.isEmpty()) {
+        authMethodInt = method;
+        if (method == "userpass") {
+            userNameInt = settings.value("username", "").toString();
             QString pass = settings.value("password", "").toString();
-            if (!pass.isEmpty()) {
-                userNameInt = user;
+            if (!userNameInt.isEmpty() && !pass.isEmpty()) {
                 passwordInt = pass;
                 foundServer = true;
             }
+        } else if (method == "pat") {
+            patTokenInt = settings.value("PAT", "").toString();
+            if (!patTokenInt.isEmpty())
+                foundServer = true;
+        } else { // cloud
+            userNameInt = settings.value("email", "").toString();
+            apiTokenInt = settings.value("apiToken", "").toString();
+            if (!userNameInt.isEmpty() && !apiTokenInt.isEmpty())
+                foundServer = true;
         }
     }
-    qDebug() << __func__ << " n=" << n << "usePAT=" << authUsingPATInt << " userName=" << userNameInt;
+    qDebug() << __func__ << " n=" << n << " method=" << authMethodInt << " userName=" << userNameInt;
 
     return foundServer;
 }
@@ -195,26 +197,27 @@ bool JiraAgent::setQuery(const QString &s)  // FIXME-3 only works for first serv
                               // Search for project = PATTERN and use resulting server
 
     settings.beginGroup("/atlassian/jira/servers/1");
-    bool usePAT = settings.value("authUsingPAT", true).toBool();    // FIXME-3 should be done in setJiraServer
+    QString method = settings.value("method", "userpass").toString();
     QString url = settings.value("baseUrl", "").toString();
     if (!url.isEmpty()) {
         baseUrlInt = url;
-        //qDebug() << "JA::setQuery  url=" <<url;
-        QString pat = settings.value("PAT", "").toString();
-        if (!pat.isEmpty()) {
-            // Use PAT
-            personalAccessTokenInt = pat;
-            foundServer = true;
-        }
-
-        QString user = settings.value("username", "").toString();
-        if (!user.isEmpty()) {
+        authMethodInt = method;
+        if (method == "userpass") {
+            userNameInt = settings.value("username", "").toString();
             QString pass = settings.value("password", "").toString();
-            if (!pass.isEmpty()) {
-                userNameInt = user;
+            if (!userNameInt.isEmpty() && !pass.isEmpty()) {
                 passwordInt = pass;
                 foundServer = true;
             }
+        } else if (method == "pat") {
+            patTokenInt = settings.value("PAT", "").toString();
+            if (!patTokenInt.isEmpty())
+                foundServer = true;
+        } else { // cloud
+            userNameInt = settings.value("email", "").toString();
+            apiTokenInt = settings.value("apiToken", "").toString();
+            if (!userNameInt.isEmpty() && !apiTokenInt.isEmpty())
+                foundServer = true;
         }
     }
     settings.endGroup();
@@ -332,27 +335,24 @@ void JiraAgent::startGetTicketRequest()
 
     QNetworkRequest request = QNetworkRequest(u);
 
-    // Basic authentication in header
     QString headerData;
-
-    if (authUsingPATInt) {
-        //headerData = QString("Bearer %1").arg(personalAccessTokenInt);
-        QString concatenated = userNameInt + ":" + personalAccessTokenInt;
+    if (authMethodInt == "pat") {
+        headerData = QString("Bearer %1").arg(patTokenInt);
+    } else if (authMethodInt == "cloud") {
+        QString concatenated = userNameInt + ":" + apiTokenInt;
         QByteArray data = concatenated.toLocal8Bit().toBase64();
         headerData = "Basic " + data;
-        // qDebug() << " - UN + PAT: " << concatenated;
-    } else {
+    } else { // userpass
         QString concatenated = userNameInt + ":" + passwordInt;
         QByteArray data = concatenated.toLocal8Bit().toBase64();
         headerData = "Basic " + data;
-        // qDebug() << " - UN + PW: " << concatenated;
     }
 
     request.setRawHeader("Authorization", headerData.toLocal8Bit());
 
     if (debug) {
         qDebug() << "JA::startGetTicketRequest: url = " + request.url().toString();
-        qDebug() << "                  authUsingPAT = " << authUsingPATInt;
+        qDebug() << "                  method = " << authMethodInt;
     }
 
     killTimer->start();
@@ -402,19 +402,17 @@ void JiraAgent::startQueryRequest()
 
     QNetworkRequest request = QNetworkRequest(u);
 
-    // Basic authentication in header
     QString headerData;
-    if (authUsingPATInt) {
-        //headerData = QString("Bearer %1").arg(personalAccessTokenInt);
-        QString concatenated = userNameInt + ":" + personalAccessTokenInt;
+    if (authMethodInt == "pat") {
+        headerData = QString("Bearer %1").arg(patTokenInt);
+    } else if (authMethodInt == "cloud") {
+        QString concatenated = userNameInt + ":" + apiTokenInt;
         QByteArray data = concatenated.toLocal8Bit().toBase64();
         headerData = "Basic " + data;
-        // qDebug() << " - UN + PAT: " << concatenated;
-    } else {
+    } else { // userpass
         QString concatenated = userNameInt + ":" + passwordInt;
         QByteArray data = concatenated.toLocal8Bit().toBase64();
         headerData = "Basic " + data;
-        // qDebug() << " - UN + PW: " << concatenated;
     }
     request.setRawHeader("Authorization", headerData.toLocal8Bit());
 

--- a/src/jira-agent.h
+++ b/src/jira-agent.h
@@ -71,8 +71,9 @@ class JiraAgent : public QObject {
     QJsonObject jsobj;
 
     // Settings: Credentials to access JIRA
-    bool authUsingPATInt;
-    QString personalAccessTokenInt;
+    QString authMethodInt; // userpass | pat | cloud
+    QString patTokenInt;
+    QString apiTokenInt;
     QString userNameInt;
     QString passwordInt;
 

--- a/src/jira-settings-dialog.cpp
+++ b/src/jira-settings-dialog.cpp
@@ -1,6 +1,7 @@
 #include "jira-settings-dialog.h"
 
 #include <QDebug>
+#include <QSignalBlocker>
 
 #include "settings.h"
 
@@ -13,7 +14,7 @@ JiraSettingsDialog::JiraSettingsDialog(QWidget *parent) : QDialog(parent)
     QDialog::setWindowTitle("VYM - " +
                             tr("Jira settings", "Jira settings dialog title"));
 
-    ui.tableWidget->setColumnCount(5);
+    ui.tableWidget->setColumnCount(4);
 
         settings.beginGroup("/atlassian/jira");
         QTableWidgetItem *newItem;
@@ -23,7 +24,6 @@ JiraSettingsDialog::JiraSettingsDialog(QWidget *parent) : QDialog(parent)
         headers << "URL";
         headers << "Pattern";
         headers << "Method";
-        headers << "User";
         ui.tableWidget->setHorizontalHeaderLabels(headers);
 
         int size = settings.beginReadArray("servers");
@@ -41,14 +41,14 @@ JiraSettingsDialog::JiraSettingsDialog(QWidget *parent) : QDialog(parent)
                 newItem = new QTableWidgetItem(settings.value("pattern").toString());
                 ui.tableWidget->setItem(0, 2, newItem);
 
-                if (settings.value("authUsingPAT").toString() == "true")
+                QString method = settings.value("method", "userpass").toString();
+                if (method == "userpass")
+                    newItem = new QTableWidgetItem("Username/Password");
+                else if (method == "pat")
                     newItem = new QTableWidgetItem("PAT");
                 else
-                    newItem = new QTableWidgetItem("Username/Password");
+                    newItem = new QTableWidgetItem("Cloud");
                 ui.tableWidget->setItem(0, 3, newItem);
-
-                newItem = new QTableWidgetItem(settings.value("username","-").toString());
-                ui.tableWidget->setItem(0, 4, newItem);
             }
         }
         settings.endArray();
@@ -71,7 +71,11 @@ JiraSettingsDialog::JiraSettingsDialog(QWidget *parent) : QDialog(parent)
             this, SLOT(fieldsChanged()));
     connect(ui.PATLineEdit, SIGNAL(editingFinished()), 
             this, SLOT(fieldsChanged()));
-    connect(ui.usePATCheckBox, SIGNAL(clicked()), 
+    connect(ui.apiTokenLineEdit, SIGNAL(editingFinished()), 
+            this, SLOT(fieldsChanged()));
+    connect(ui.authMethodComboBox, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(updateAuthenticationFields()));
+    connect(ui.authMethodComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(fieldsChanged()));
     connect(ui.tableWidget, SIGNAL(cellChanged(int, int)),
             this, SLOT(fieldsChanged()));
@@ -91,29 +95,35 @@ void JiraSettingsDialog::deleteServer()
 
 void JiraSettingsDialog::updateAuthenticationFields()
 {
-    QModelIndexList ixl = ui.tableWidget->selectionModel()->selectedIndexes();
-
-    int row;
-    if (ixl.isEmpty() || ixl.count() > 1)
-        row = -1;
-    else
-        row = ixl.first().row();
+    int rowCount = ui.tableWidget->rowCount();
+    int row = -1;
+    if (ui.tableWidget->selectionModel()) {
+        QModelIndexList sel = ui.tableWidget->selectionModel()->selectedIndexes();
+        if (!sel.isEmpty()) row = sel.first().row();
+    }
 
     if (row < 0) {
-        // No server selected, disable fields
         ui.selectedServerLineEdit->setText("");
-        ui.usePATCheckBox->setEnabled(false);
+        ui.authMethodComboBox->setEnabled(false);
+        ui.authMethodComboBox->hide();
+        ui.authMethodLabel->hide();
         ui.PATLineEdit->setEnabled(false);
-        ui.PATLabel->setEnabled(false);
-        ui.userLabel->setEnabled(false);
+        ui.PATLineEdit->hide();
+        ui.PATLabel->hide();
+        ui.apiTokenLineEdit->setEnabled(false);
+        ui.apiTokenLineEdit->hide();
+        ui.apiTokenLabel->hide();
         ui.userLineEdit->setEnabled(false);
-        ui.passwordLabel->setEnabled(false);
+        ui.userLineEdit->hide();
+        ui.userLabel->hide();
         ui.passwordLineEdit->setEnabled(false);
+        ui.passwordLineEdit->hide();
+        ui.passwordLabel->hide();
 
-        // Empty unused fields
         ui.userLineEdit->setText("");
         ui.passwordLineEdit->setText("");
         ui.PATLineEdit->setText("");
+        ui.apiTokenLineEdit->setText("");
 
     } else {
         // Index of selected server in settings
@@ -125,57 +135,75 @@ void JiraSettingsDialog::updateAuthenticationFields()
             ui.selectedServerLineEdit->setText( ui.tableWidget->item(row, 0)->text());
         else
             ui.selectedServerLineEdit->setText("");
-        ui.usePATCheckBox->setEnabled(true);
-        ui.usePATCheckBox->setChecked(
-            settings.value(selectedServer + "authUsingPAT", true).toBool());
+        // Block signal emissions while updating widgets to avoid re-entrancy
+        QSignalBlocker blockCombo(ui.authMethodComboBox);
+        QSignalBlocker blockUser(ui.userLineEdit);
+        QSignalBlocker blockPass(ui.passwordLineEdit);
+        QSignalBlocker blockPat(ui.PATLineEdit);
+
+        ui.authMethodComboBox->setEnabled(true);
+        ui.authMethodComboBox->show();
+        ui.authMethodLabel->show();
         ui.PATLineEdit->setEnabled(true);
         ui.PATLabel->setEnabled(true);
+        ui.apiTokenLineEdit->setEnabled(true);
+        ui.apiTokenLabel->setEnabled(true);
         ui.userLabel->setEnabled(true);
         ui.userLineEdit->setEnabled(true);
         ui.passwordLabel->setEnabled(true);
         ui.passwordLineEdit->setEnabled(true);
 
-        // Show and prefill fields depending on usage of PAT
-        if (ui.usePATCheckBox->isChecked()) {
+        int methodIdx = ui.authMethodComboBox->currentIndex();
+        if (methodIdx == 2) { // cloud
+            ui.apiTokenLineEdit->show();
+            ui.apiTokenLineEdit->setText(
+                settings.value(selectedServer + "apiToken","").toString());
+            ui.apiTokenLabel->show();
+            ui.PATLineEdit->hide();
+            ui.PATLabel->hide();
+            ui.userLabel->show();
+            ui.userLabel->setText(tr("Email:"));
+            ui.userLineEdit->show();
+            ui.userLineEdit->setText(
+                settings.value(QString("/atlassian/jira/servers/%1/email").arg(n_server), "").toString());
+            ui.passwordLabel->hide();
+            ui.passwordLineEdit->hide();
+        } else if (methodIdx == 1) { // PAT
             ui.PATLineEdit->show();
             ui.PATLineEdit->setText(
                 settings.value(selectedServer + "PAT","").toString());
-                settings.value(selectedServer + "PAT","").toString();
             ui.PATLabel->show();
+            ui.apiTokenLineEdit->hide();
+            ui.apiTokenLabel->hide();
             ui.userLabel->hide();
             ui.userLineEdit->hide();
             ui.passwordLabel->hide();
             ui.passwordLineEdit->hide();
-        } else {
+        } else { // user/pass
             ui.PATLineEdit->hide();
             ui.PATLabel->hide();
+            ui.apiTokenLineEdit->hide();
+            ui.apiTokenLabel->hide();
             ui.userLabel->show();
+            ui.userLabel->setText(tr("Username:"));
             ui.userLineEdit->show();
             ui.userLineEdit->setText(
-                settings.value(QString("/atlassian/jira/servers/%1/username").arg(n_server), "-").toString());
+                settings.value(QString("/atlassian/jira/servers/%1/username").arg(n_server), "").toString());
             ui.passwordLabel->show();
             ui.passwordLineEdit->show();
             ui.passwordLineEdit->setText(
                 settings.value(QString("/atlassian/jira/servers/%1/password").arg(n_server), "").toString());
         }
     }
-
-    // Update layout
-    adjustSize();
 }
 
 
 void JiraSettingsDialog::fieldsChanged()
 {
     int rowCount = ui.tableWidget->rowCount();
-
     if (rowCount < 1) return;
-
-    QModelIndexList ixl = ui.tableWidget->selectionModel()->selectedIndexes();
-
-    if (ixl.isEmpty() || ixl.count() > 1) return;
-
-    int row = ixl.first().row();
+    int row = ui.tableWidget->currentRow();
+    if (row < 0 || row >= rowCount) return;
     int n_server = rowCount - 1 - row;
 
     if (n_server < 0) return;
@@ -196,24 +224,63 @@ void JiraSettingsDialog::fieldsChanged()
         settings.setValue("pattern", ui.tableWidget->item(row, 2)->text());
     else
         settings.setValue("pattern", "");
-    settings.setValue("authUsingPAT", ui.usePATCheckBox->isChecked());
-    if (ui.usePATCheckBox->isChecked()) {
-        // Don't save password if PAT is used
-        settings.remove("password");
-        settings.setValue("PAT", ui.PATLineEdit->text());
-    } else {
+
+    int methodIdx = ui.authMethodComboBox->currentIndex();
+    QString method = (methodIdx == 0) ? "userpass" : (methodIdx == 1) ? "pat" : "cloud";
+    settings.setValue("method", method);
+    if (method == "userpass") {
         settings.setValue("username", ui.userLineEdit->text());
         settings.setValue("password", ui.passwordLineEdit->text());
-        settings.remove("PAT");
+    } else if (method == "pat") {
+        settings.setValue("PAT", ui.PATLineEdit->text());
+    } else { // cloud
+        settings.setValue("email", ui.userLineEdit->text());
+        settings.setValue("apiToken", ui.apiTokenLineEdit->text());
     }
     settings.setValue("servers/size", rowCount);
 
     settings.endArray();
     settings.endGroup();
+
+    // Reflect method in table overview without re-triggering cellChanged
+    {
+        QSignalBlocker blockTable(ui.tableWidget);
+        QString methodText = (method == "userpass") ? "Username/Password" : (method == "pat") ? "PAT" : "Cloud";
+        QTableWidgetItem *methodItem = new QTableWidgetItem(methodText);
+        ui.tableWidget->setItem(row, 3, methodItem);
+    }
 }
 
 void JiraSettingsDialog::selectionChanged(const QItemSelection &selected, const QItemSelection &)
 {
+    Q_UNUSED(selected);
+
+    // If nothing selected, just refresh to the hidden state
+    if (!ui.tableWidget->selectionModel() ||
+        ui.tableWidget->selectionModel()->selectedIndexes().isEmpty()) {
+        updateAuthenticationFields();
+        return;
+    }
+
+    int row = ui.tableWidget->selectionModel()->selectedIndexes().first().row();
+    int rowCount = ui.tableWidget->rowCount();
+    if (row < 0 || row >= rowCount) {
+        updateAuthenticationFields();
+        return;
+    }
+
+    int n_server = rowCount - row; // absolute numbering used in settings path
+    QString selectedServer = QString("/atlassian/jira/servers/%1/").arg(n_server);
+
+    // Load and set method for selected server without triggering save yet
+    QString method = settings.value(selectedServer + "method", "userpass").toString();
+    int methodIndex = 0; // 0=userpass,1=pat,2=cloud
+    if (method == "pat") methodIndex = 1;
+    else if (method == "cloud") methodIndex = 2;
+    {
+        QSignalBlocker blockCombo(ui.authMethodComboBox);
+        ui.authMethodComboBox->setCurrentIndex(methodIndex);
+    }
+
     updateAuthenticationFields();
 }
-

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2238,7 +2238,7 @@ void Main::setupEditActions()
     switchboard.addSwitch("mapSetJiraQuery", shortcutScope, tag, a);
     addAction(a);
     connect(a, SIGNAL(triggered()), this, SLOT(setJiraQuery()));
-    actionGetJiraDataSubtree = a;
+    actionSetJiraQuery = a;
 
     a = new QAction(tr("Get page name and details from Confluence", "Edit menu"),
                     this);
@@ -3091,6 +3091,7 @@ void Main::setupConnectActions()
     connectMenu->addAction(actionGetConfluencePageDetails);
     connectMenu->addAction(actionGetConfluencePageDetailsRecursively);
     connectMenu->addAction(actionGetJiraDataSubtree);
+    connectMenu->addAction(actionSetJiraQuery);
 
     connectMenu->addSeparator();
 
@@ -8217,4 +8218,3 @@ void Main::toggleHideTmpMode()
     if (m)
         m->toggleHideTmpMode();
 }
-

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -525,6 +525,7 @@ class Main : public QMainWindow {
     QAction *actionLocalURL;
     QAction *actionHeading2URL;
     QAction *actionGetJiraDataSubtree;
+    QAction *actionSetJiraQuery;
     QAction *actionGetConfluencePageDetails;
     QAction *actionGetConfluencePageDetailsRecursively;
     QAction *actionOpenVymLink;


### PR DESCRIPTION
I discovered vym last week and, after reading the manual, decided to give it a try. It feels fast while staying pleasantly simple. Since we use Jira at work, I built from source (instead of the `apt` package) to get the latest Jira features.

Getting Jira working on the current `HEAD` was tricky. On top of the auth issues (see below), it wasn’t obvious whether the connection was being triggered. I eventually found the `Shift+J` shortcut (“Get Jira data for subtree”) and noticed the action already exists in the codebase but wasn’t wired into the context menu. I hooked it up to the node context menu—just wiring an existing action—so it’s much easier to test and diagnose the Jira connection.

Regarding authentication: Jira Cloud needs **Basic** auth with **email + API token**, while the current settings seem oriented toward on-prem (PAT or username/password). As a stopgap, I got Cloud working by editing the config directly and nudging vym into using Basic instead of Bearer. For reference, this worked (edited outside the Jira settings dialog):

```
[atlassian]
jira\servers\1\PAT="<my_api_token>"
jira\servers\1\authUsingPAT=true
jira\servers\1\baseUrl=https://my-custom-instance.atlassian.net/
jira\servers\1\name=MyServer
jira\servers\1\password=dummy
jira\servers\1\pattern=FLEX
jira\servers\1\username=loric.brevet@gmail.com
jira\servers\size=1
```

Because `username` and `password` were both set, the code used `Basic`; with `authUsingPAT=true`, it sent email + PAT as credentials. That worked, but it’s clearly a workaround rather than a first-class path for Jira Cloud.

This PR:

- adds explicit auth modes (Username/Password, PAT, Jira Cloud with email + API token), each with distinct fields, and
- wires the existing “Get Jira data for subtree” action into the node context menu (same as `Shift+J`).

This is a first pass after an initial read of the codebase, and I’m not deeply familiar with C++. The changes were kept intentionally simple; backwards compatibility with previous configs was not taken seriously here, so it’s unclear whether anything breaks because of that.

Thanks for building vym—I’m enjoying it; the code could be adapted if it doesn’t match vym’s style.