### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# CMake files
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+install_manifest.txt
+Makefile
+
+# Qt/CMake autogen and deploy
+vym_autogen/
+.qt/
+
+# Built binary
+vym
+
+# Qt translation artifacts
+translations/*.qm


### PR DESCRIPTION
The project currently does not have a `.gitignore` file.

So if I try to build it with:

```
cmake .
make
```

I end up with plenty of untracked files.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.qt/
	CMakeCache.txt
	CMakeFiles/
	Makefile
	build/
	cmake_install.cmake
	install_manifest.txt
	pkg/
	translations/
	vym
	vym_autogen/
```

To remedy that, I propose the addition of a simple `.gitignore` file that will ignore those dirty files generated for the build.

If it is not complete, lines can be further added in the future.