### PR TITLE
cmake: install resources under share/vym and set VYMBASEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,10 @@ message(STATUS "  vymDemos: ${vymDemos}")
 message(STATUS " vymMacros: ${vymMacros}")
 message(STATUS "vymScripts: ${vymScripts}")
 
-ADD_COMPILE_DEFINITIONS(VYMBASEDIR="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}")
+# On Unix-like systems, place app data under a dedicated subdir
+# so runtime looks in .../share/vym for resources.
+set(VYM_SHARE_SUBDIR "vym")
+ADD_COMPILE_DEFINITIONS(VYMBASEDIR="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/${VYM_SHARE_SUBDIR}")
 
 add_executable(vym ${VymSources} vym.qrc ${qm_files})
 target_link_libraries(vym ${QtLibraries})
@@ -207,11 +210,11 @@ add_custom_target(make-translations-directory ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/translations)
 add_dependencies(vym make-translations-directory)
 
-install(DIRECTORY demos DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})
+install(DIRECTORY demos DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${VYM_SHARE_SUBDIR})
 install(DIRECTORY doc DESTINATION ${CMAKE_INSTALL_DOCDIR} FILES_MATCHING PATTERN "*.pdf")
 install(FILES doc/vym.1.gz DESTINATION ${CMAKE_INSTALL_MANDIR})
 install(FILES README.md LICENSE.txt DESTINATION ${CMAKE_INSTALL_DOCDIR})
-install(DIRECTORY exports flags icons macros ${CMAKE_BINARY_DIR}/translations scripts styles DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})
+install(DIRECTORY exports flags icons macros ${CMAKE_BINARY_DIR}/translations scripts styles DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${VYM_SHARE_SUBDIR})
 
 if(UNIX)
     install(FILES icons/vym.png DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/48x48/apps)


### PR DESCRIPTION
### Summary

- Move vym’s shared resources under `share/vym` and align runtime lookup via `VYMBASEDIR`.
- Keeps binary, desktop entry, MIME, and icons in standard locations.

### Background

- Previously, CMake installed data folders (`demos`, `icons`, `flags`, `styles`, `macros`, `translations`, `scripts`, `exports`) directly into `share/` (e.g., `share/demos/`).
- This clutters the global namespace and risks conflicts with other applications.
- The FHS recommends using a subdirectory under `/usr/share` (or `/usr/local/share`) for application data: “It is recommended that a subdirectory be used in `/usr/share` for this purpose.”

### What Changed

- Install app data to `${CMAKE_INSTALL_DATAROOTDIR}/vym/...` instead of `${CMAKE_INSTALL_DATAROOTDIR}/....`
- Define `VYMBASEDIR` as `${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/vym` so the runtime looks for resources in `.../share/vym`.
- No changes to:
    - Binary install (`bin/` on Unix; custom path on Windows)
    - Desktop file, MIME XML, and app icon (use standard system dirs)
    - Docs and man page destinations (remain as before)

### Compatibility Notes

- Linux: Applications and packaging scripts referencing old flat `share/` paths should be updated to `share/vym/....`
- macOS/Windows: Unchanged behavior (macOS bundles use `Resources/`, Windows uses the executable dir).
- Users can still override resources via `VYMHOME` or `--local` if needed.

### How To Verify

- Configure, build inside of a `build/` folder, and stage install in `pkg/`:
    - `cmake -B build -S .`
    - `cmake --build build`
    - `DESTDIR="$(pwd)/pkg" cmake --install build`
- Check:
    - `pkg/usr/local/share/vym/{demos,icons,flags,styles,macros,translations,exports,scripts}`
    - `pkg/usr/local/bin/vym`
    - `pkg/usr/local/share/applications/vym.desktop`
    - `pkg/usr/local/share/mime/packages/vym.xml`
    - `pkg/usr/local/share/icons/hicolor/48x48/apps/vym.png`