### PR TITLE
AppStream / Metainfo Improvements

### DIFF
--- a/config/io.github.insilmaril.vym.appdata.xml
+++ b/config/io.github.insilmaril.vym.appdata.xml
@@ -25,7 +25,7 @@
         <category>Office</category>
     </categories>
     <url type="bugtracker">https://github.com/insilmaril/vym/issues</url>
-    <url type="homepage">http://www.insilmaril.de/vym/</url>
+    <url type="homepage">https://www.insilmaril.de/vym/</url>
     <developer id="io.github.insilmaril.vym">
       <name>Uwe Drechsel</name>
     </developer>
@@ -38,7 +38,7 @@
     <provides>
         <binary>vym</binary>
     </provides>
-    <translation type="gettext">vym</translation>
+    <translation type="qt">vym/translations</translation>
     <content_rating type="oars-1.1">
         <content_attribute id="social-info">mild</content_attribute>
     </content_rating>


### PR DESCRIPTION
Translations are maintained as Qt translations and not using gettex. Now we face the issue of figuring out the translation location. With PR https://github.com/insilmaril/vym/pull/167 and based on what Debian is already doing, translations end up in `/usr/share/vym/translations`.

Upstream Documentation mentions the following pattern for Qt translations:

For Qt translations, if the ID string contains slashes, we will look for translations following either the
`${prefix}/share/${id}_${locale}.qm` or the
`${prefix}/share/${id}/${locale}.qm` pattern.

Based on that I assume `vym/translations` would be inserted as `{id}` in the second pattern and match what PR#167 would install.

Docs: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-translation

Homepage should nowadays by default be referenced via https.