### PR TITLE
Add Help > VYM Development entry to download and show page inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ vym
 
 # Qt translation artifacts
 translations/*.qm
+
+# Temporary files
+tmp/

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3720,6 +3720,11 @@ void Main::setupHelpActions()
     helpMenu->addAction(a);
     connect(a, SIGNAL(triggered()), this, SLOT(helpDebugInfo()));
 
+    helpMenu->addSeparator();
+    a = new QAction(tr("Help VYM development", "Help action"), this);
+    helpMenu->addAction(a);
+    connect(a, SIGNAL(triggered()), this, SLOT(helpVymDevelopment()));
+
     a = new QAction(tr("About QT", "Help action"), this);
     connect(a, SIGNAL(triggered()), this, SLOT(helpAboutQT()));
     helpMenu->addAction(a);
@@ -7948,6 +7953,39 @@ void Main::helpDebugInfo()
     dia.setText(debugInfo());
     dia.setMinimumWidth(900);
     dia.exec();
+}
+
+void Main::helpVymDevelopment()
+{
+    DownloadAgent *agent =
+        new DownloadAgent(QUrl("https://www.insilmaril.de/vym/helpVymDevelopment.html"));
+    connect(agent, SIGNAL(downloadFinished()), this,
+            SLOT(helpVymDevelopmentFinished()));
+    QTimer::singleShot(0, agent, SLOT(execute()));
+}
+
+void Main::helpVymDevelopmentFinished()
+{
+    DownloadAgent *agent = static_cast<DownloadAgent *>(sender());
+
+    if (agent->isSuccess()) {
+        QString page;
+        if (loadStringFromDisk(agent->getDestination(), page)) {
+            ShowTextDialog dia(this);
+            dia.setText(page);
+            dia.exec();
+        }
+    }
+    else {
+        statusMessage("Downloading VYM development page failed.");
+	logInfo("Failed to download page: " + agent->getResultMessage(), __func__);
+        if (debug) {
+            qDebug() << "Main::helpVymDevelopmentFinished ";
+            qDebug() << "  result: failed";
+            qDebug() << "     msg: " << agent->getResultMessage();
+        }
+    }
+    agent->deleteLater();
 }
 
 void Main::helpAbout()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -431,6 +431,8 @@ class Main : public QMainWindow {
     void helpDebugInfo();
     void helpAbout();
     void helpAboutQT();
+    void helpVymDevelopment();
+    void helpVymDevelopmentFinished();
     void callMacro();
     void downloadReleaseNotesFinished();
 


### PR DESCRIPTION
  - What: new Help menu entry "Help VYM development" that fetches https://www.insilmaril.de/vym/helpVymDevelopment.html via DownloadAgent and shows the result in ShowTextDialog
  - Why: previously the slot was empty; displaying inline avoids opening an external browser
  - Pattern: follows the same DownloadAgent → downloadFinished() → ShowTextDialog pattern as downloadReleaseNotesFinished()
